### PR TITLE
feat: extension MaxAliasesLimiter

### DIFF
--- a/strawberry/extensions/max_aliases.py
+++ b/strawberry/extensions/max_aliases.py
@@ -1,0 +1,74 @@
+from typing import Type
+
+from graphql import (
+    ExecutableDefinitionNode,
+    FieldNode,
+    GraphQLError,
+    InlineFragmentNode,
+    ValidationContext,
+    ValidationRule,
+)
+
+from strawberry.extensions.add_validation_rules import AddValidationRules
+
+
+class MaxAliasesLimiter(AddValidationRules):
+    """
+    Add a validator to limit the number of aliases used.
+
+    Example:
+
+    >>> import strawberry
+    >>> from strawberry.extensions import QueryDepthLimiter
+    >>>
+    >>> schema = strawberry.Schema(
+    ...     Query,
+    ...     extensions=[
+    ...         MaxAliasesLimiter(max_alias_count=15)
+    ...     ]
+    ... )
+
+    Arguments:
+
+    `max_alias_count: int`
+        The maximum number of aliases allowed in a GraphQL document.
+    """
+
+    def __init__(
+        self,
+        max_alias_count: int,
+    ):
+        validator = create_validator(max_alias_count)
+        super().__init__([validator])
+
+
+def create_validator(max_alias_count: int) -> Type[ValidationRule]:
+    class MaxAliasesValidator(ValidationRule):
+        def __init__(self, validation_context: ValidationContext):
+            document = validation_context.document
+            def_that_can_contain_alias = [
+                def_
+                for def_ in document.definitions
+                if isinstance(def_, (ExecutableDefinitionNode))
+            ]
+            total_aliases = sum(
+                count_fields_with_alias(def_node)
+                for def_node in def_that_can_contain_alias
+            )
+            if total_aliases > max_alias_count:
+                msg = f"{total_aliases} aliases found. Allowed: {max_alias_count}"
+                validation_context.report_error(GraphQLError(msg))
+
+            super().__init__(validation_context)
+
+    return MaxAliasesValidator
+
+
+def count_fields_with_alias(selection_set_owner) -> int:
+    result = 0
+    for sel in selection_set_owner.selection_set.selections:
+        if isinstance(sel, FieldNode) and sel.alias:
+            result += 1
+        if isinstance(sel, (FieldNode, InlineFragmentNode)) and sel.selection_set:
+            result += count_fields_with_alias(sel)
+    return result

--- a/tests/schema/extensions/test_max_aliases.py
+++ b/tests/schema/extensions/test_max_aliases.py
@@ -1,0 +1,200 @@
+from typing import Dict, List, Optional, Tuple, Union
+
+from graphql import (
+    GraphQLError,
+    parse,
+    specified_rules,
+    validate,
+)
+
+import strawberry
+from strawberry.extensions.max_aliases import create_validator
+
+
+@strawberry.type
+class Human:
+    name: str
+    email: str
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def user(self, name: Optional[str], email: Optional[str]) -> Human:
+        pass
+
+    version: str
+    user1: Human
+    user2: Human
+    user3: Human
+
+
+schema = strawberry.Schema(Query)
+
+
+def run_query(
+    query: str, max_aliases: int
+) -> Tuple[List[GraphQLError], Union[Dict[str, int], None]]:
+    document = parse(query)
+
+    result = None
+
+    validation_rule = create_validator(max_aliases)
+
+    errors = validate(
+        schema._schema,
+        document,
+        rules=(*specified_rules, validation_rule),
+    )
+
+    return errors, result
+
+
+def test_2_aliases_same_content():
+    query = """
+    query read {
+      matt: user(name: "matt") {
+        email
+      }
+      matt_alias: user(name: "matt") {
+        email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 1
+    assert errors[0].message == "2 aliases found. Allowed: 1"
+    assert not result
+
+
+def test_2_aliases_different_content():
+    query = """
+    query read {
+      matt: user(name: "matt") {
+        email
+      }
+      matt_alias: user(name: "matt42") {
+        email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 1
+    assert errors[0].message == "2 aliases found. Allowed: 1"
+
+
+def test_multiple_aliases_some_overlap_in_content():
+    query = """
+    query read {
+      matt: user(name: "matt") {
+        email
+      }
+      jane: user(name: "jane") {
+        email
+      }
+      matt_alias: user(name: "matt") {
+        email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 1
+    assert errors[0].message == "3 aliases found. Allowed: 1"
+    assert not result
+
+
+def test_multiple_arguments():
+    query = """
+    query read {
+      matt: user(name: "matt", email: "matt@example.com") {
+        email
+      }
+      jane: user(name: "jane") {
+        email
+      }
+      matt_alias: user(name: "matt", email: "matt@example.com") {
+        email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 1
+    assert errors[0].message == "3 aliases found. Allowed: 1"
+    assert not result
+
+
+def test_aliased_argument():
+    query = """
+    query read {
+      matt: user(name: "matt") {
+        email_address: email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 1
+    assert errors[0].message == "2 aliases found. Allowed: 1"
+    assert not result
+
+
+def test_aliased_argument_in_fragment():
+    query = """
+    fragment humanInfo on Human {
+      email_address: email
+    }
+    query read {
+      matt: user(name: "matt") {
+        ...humanInfo
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 1
+    assert errors[0].message == "2 aliases found. Allowed: 1"
+    assert not result
+
+
+def test_no_error_one_aliased_one_without():
+    query = """
+    query read {
+      user(name: "matt") {
+        email
+      }
+      matt_alias: user(name: "matt") {
+        email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 1)
+
+    assert len(errors) == 0
+
+
+def test_no_error_for_multiple_but_not_too_many_aliases():
+    query = """
+    query read {
+      matt: user(name: "matt") {
+        email
+      }
+      matt_alias: user(name: "matt") {
+        email
+      }
+    }
+    """
+
+    errors, result = run_query(query, 2)
+
+    assert len(errors) == 0


### PR DESCRIPTION
Limit the maximum number of aliases in a GraphQL document.

Implementation
---------------------

Recursively search for aliases in `FieldNode`, `InlineFragmentNode`
